### PR TITLE
Allow envelope to support multiple layers

### DIFF
--- a/csirtg_smrt/parser/zjson.py
+++ b/csirtg_smrt/parser/zjson.py
@@ -33,7 +33,11 @@ class Json(Parser):
                 continue
 
             if envelope:
-                l = l[envelope]
+                if not isinstance(envelope, list):
+                    envelope = [envelope]
+                
+                for a in envelope:
+                    l = l[a]
 
             for e in l:
                 i = copy.deepcopy(defaults)


### PR DESCRIPTION
some APIs that return json objects with the useful data nested layers deep (apwg /mal_ip, i'm looking at you) do not seem to currently work with json parser. Add ability for envelope to peel back Matryoshka doll envelopes, e.g.:
```
{ 
  '_meta': 'some garbage', 
  '_links': 'other stuff', 
  '_embedded': {
    'mal_ips': [ 'finally the good stuff', 'oh yeah' ] 
  } 
}
```
rule.yml:
```
...
envelope:
  - _embedded
  - _mal_ips
...
```