### PR TITLE
Updates confidence mapping from Integer to Float

### DIFF
--- a/csirtg_smrt/client/zelasticsearch.py
+++ b/csirtg_smrt/client/zelasticsearch.py
@@ -31,7 +31,7 @@ class Indicator(DocType):
     reporttime = Date()
     lasttime = Date()
     firsttime = Date()
-    confidence = Integer()
+    confidence = Float()
     timezone = String()
     city = String()
     description = String(index="not_analyzed")


### PR DESCRIPTION
Float values (like 7.5 or 8.5) get stored in the Integer-mapped confidence field due to coercion [1], but when querying ES (as in a range query), the value is truncated/rounded [2]. E.g., if an indicator's conf is stored as 7.5, but you later query for indicators at 7.5, that indicator won't be returned b/c ES truncates the field value before querying to comply with the Integer mapping type. 
Fix this problem by remapping as Float.
[1]: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/coerce.html
[2]: https://github.com/elastic/elasticsearch/issues/25861#issuecomment-659508621