### PR TITLE
fix/feed bleed

### DIFF
--- a/csirtg_smrt/parser/__init__.py
+++ b/csirtg_smrt/parser/__init__.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import re
 import math
@@ -57,6 +58,19 @@ class Parser(object):
             self.line_filter = re.compile(self.line_filter)
 
         self.line_count = 0
+        
+        # prioritize column values in order: feed values > feed defaults values > rule defaults values > rule values
+        if self.rule.feeds[self.feed].get('values'):
+            self.cols = self.rule.feeds[self.feed].get('values')
+        elif self.rule.feeds[self.feed].get('defaults', {}).get('values'):
+            self.cols = self.rule.feeds[self.feed]['defaults'].get('values')
+        elif self.rule.defaults.get('values'):
+            self.cols = self.rule.defaults.get('values')
+        else:
+            self.cols = self.rule.get('values', [])
+
+        if isinstance(self.cols, str):
+            self.cols = self.cols.split(',')
 
     def ignore(self, line):
         if line == '':
@@ -82,7 +96,7 @@ class Parser(object):
             return True
 
     def _defaults(self):
-        defaults = self.rule.defaults
+        defaults = copy.deepcopy(self.rule.defaults)
 
         if self.rule.feeds[self.feed].get('defaults'):
             for d in self.rule.feeds[self.feed].get('defaults'):

--- a/csirtg_smrt/parser/delim.py
+++ b/csirtg_smrt/parser/delim.py
@@ -1,4 +1,5 @@
 from csirtg_smrt.parser import Parser
+import copy
 import re
 from pprint import pprint
 import logging
@@ -15,7 +16,6 @@ class Delim(Parser):
 
     def process(self):
         defaults = self._defaults()
-        cols = defaults.get('values', [])
 
         for l in self.fetcher.process():
             if self.ignore(l):  # comment or skip
@@ -33,14 +33,12 @@ class Delim(Parser):
             # l = l.replace('\"', '')
             # m = self.pattern.split(l)
 
-            if len(cols):
-                i = {}
-                for k, v in defaults.items():
-                    i[k] = v
+            if len(self.cols):
+                i = copy.deepcopy(defaults)
 
                 #pprint(i)
-                for idx, col in enumerate(cols):
-                    if col is not None:
+                for idx, col in enumerate(self.cols):
+                    if col:
                         try:
                             i[col] = m[idx]
                         except IndexError as e:


### PR DESCRIPTION
In multi-feed yml rules, it was possible for different settings from one feed to affect subsequent feeds in the same rule if their runs didn't include previously set attributes. E.g.:

**rule.yml**
```
parser: pipe
defaults:
  tags:
    - scanner
    - bruteforce
  provider: blueteam.tld
  confidence: 9
  values:
    - null
    - null
    - indicator
    - lasttime
    - null

feeds:
  feed1:
    defaults:
      tags:
        - scanner
        - dns
      description: 'feed1 desc'

  feed2:
    defaults:
      description: 'feed2 desc'
    values:
      - null
      - null
      - indicator
      - firsttime
      - lasttime
      - null
```
B/c feed2 doesn't have a `tags` attribute, if it's processed after feed1, it may incorrectly inherit the same feed1 tags rather than the parent rule tags. Additionally, new values such as those defined in feed 2 wouldn't previously have overwritten the rule's values and would have tried to incorrectly parse columns. This PR adjusts that as well.

_Note:_
This code change may impact how currently written smrt parser rules are ingested. If smrt rules were intentionally adjusted to work around these issues, they may need to be reviewed to ensure rules are still parsed as expected (though I tested with 3 dozen rules of my own and there were no unexpected changes). 
