### PR TITLE
changes remote var when handling error

### DIFF
--- a/csirtg_smrt/parser/zstix.py
+++ b/csirtg_smrt/parser/zstix.py
@@ -17,8 +17,7 @@ class Stix(Parser):
         try:
             feed = STIXPackage.from_xml(self.rule.remote)
         except Exception as e:
-            self.logger.error('Error parsing feed: {}'.format(e))
-            self.logger.error(defaults['remote'])
+            self.logger.error('Error parsing feed {}: {}'.format(self.rule.remote, e))
             raise e
 
         d = feed.to_dict()


### PR DESCRIPTION
`defaults['remote']` may not exist but `self.rule.remote` should.