### PR TITLE
Support whitespace between commas

### DIFF
--- a/csirtg_smrt/parser/delim.py
+++ b/csirtg_smrt/parser/delim.py
@@ -23,7 +23,7 @@ class Delim(Parser):
 
             if (l.startswith('"') or l.startswith("'") and self.pattern == re.compile(',')) or (l.count(',') > 2):
                 import csv
-                r = csv.reader([l], delimiter=',', quotechar='"')
+                r = csv.reader([l], delimiter=',', quotechar='"', skipinitialspace=True)
                 m = next(r)
                # pprint(m)
             else:


### PR DESCRIPTION
This enables `parser: csv` to handle spaces between csvs so a custom regex pattern parser isn't necessary, e.g.:
```
"bad.tld", "phishing", "very menacing stuff here"
```